### PR TITLE
Fix display of multiline names with `-nameopt multiline`

### DIFF
--- a/x509-mode.el
+++ b/x509-mode.el
@@ -301,7 +301,6 @@ Display result in another buffer.
 With \\[universal-argument] prefix, you can edit the command arguements."
   (interactive (x509--read-arguments
                 "x509 args: "
-                (format "x509 -nameopt utf8 -text -noout -inform %s"
                 (format "x509 -nameopt multiline,utf8 -text -noout -inform %s"
                         (x509--buffer-encoding))
                 'x509--viewcert-history))

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -302,6 +302,7 @@ With \\[universal-argument] prefix, you can edit the command arguements."
   (interactive (x509--read-arguments
                 "x509 args: "
                 (format "x509 -nameopt utf8 -text -noout -inform %s"
+                (format "x509 -nameopt multiline,utf8 -text -noout -inform %s"
                         (x509--buffer-encoding))
                 'x509--viewcert-history))
   (x509--process-buffer (split-string-and-unquote args))


### PR DESCRIPTION
This is to fix `x509-viewcert` erroring on multiline issuer:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    Signature Algorithm: sha256WithRSAEncryption
        Issuer: 
```