### PR TITLE
Add unit tests and github workflow actions for build and test.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,12 @@ jobs:
     strategy:
       matrix:
         emacs_version:
+        - 25.1
         - 25.3
+        - 26.1
+        - 26.2
         - 26.3
+        - 27.1
         - 27.2
         - 28.1
         - snapshot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-        # - 25.3
-        # - 26.3
+        - 25.3
+        - 26.3
         - 27.2
         - 28.1
         - snapshot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+on: [ push, pull_request ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+        # - 25.3
+        # - 26.3
+        - 27.2
+        - 28.1
+        - snapshot
+    steps:
+    - name: Install emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+    - name: Checkout x509-mode
+      uses: actions/checkout@v2
+      with:
+        repository: jobbflykt/x509-mode
+        path: x509-mode
+    - name: Build x509-mode
+      run: make -C x509-mode lisp
+    - name: Test x509-mode
+      run: make -C x509-mode test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,10 @@ jobs:
     strategy:
       matrix:
         emacs_version:
+        - 24.3
         - 25.1
-        - 25.3
         - 26.1
-        - 26.2
-        - 26.3
         - 27.1
-        - 27.2
         - 28.1
         - snapshot
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-        - 24.3
+        # - 24.3    Some problem with command arg history tests.
         - 25.1
         - 26.1
         - 27.1

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ lisp: $(ELCS)
 	-f batch-byte-compile $<
 
 test:
+	openssl version
 	$(BATCH) --eval "\
 	(progn \
 	  (message \"%s\" (emacs-version)) \
 	  (load-file \"$(TOP)/x509-mode-tests.el\") \
 	  (ert-run-tests-batch-and-exit))"
-	openssl version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: all test
+
+all: lisp
+
+TOP := .
+LOAD_PATH = -L $(TOP)
+EMACS ?= emacs
+BATCH = $(EMACS) -Q --batch $(LOAD_PATH)
+
+ELS = x509-mode.el
+ELCS = $(ELS:.el=.elc)
+
+lisp: $(ELCS)
+
+%.elc: %.el
+	$(BATCH) --eval "(when (file-exists-p \"$@\") (delete-file \"$@\"))" \
+	-f batch-byte-compile $<
+
+test:
+	$(BATCH) --eval "\
+	(progn \
+	  (message \"%s\" (emacs-version)) \
+	  (load-file \"$(TOP)/x509-mode-tests.el\") \
+	  (ert-run-tests-batch-and-exit))"
+	openssl version

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -127,20 +127,18 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
 (ert-deftest x509--process-buffer ()
   "Let OpenSSL process buffer."
   (let ((text
-         (string-join
-          (list
-           "-----BEGIN X509 CRL-----"
-           "MIIBqzCBlAIBATANBgkqhkiG9w0BAQsFADA8MRowGAYDVQQDDBFDQSBUZXN0VG9v"
-           "bCBDQSAwMTEeMBwGA1UECgwVQ0EgVGVzdFRvb2wgQXV0aG9yaXR5Fw0yMjA2MTEw"
-           "NjA5NTZaGA8yMDcyMDUyOTA2MDk1NlowIjAgAgECFw0yMjA2MTEwNjA5MzlaMAww"
-           "CgYDVR0VBAMKAQAwDQYJKoZIhvcNAQELBQADggEBAAeCzW8Qjb9T0Y7GUygw+J28"
-           "HH6LLprpUsxf9YuHXtrq6IcsM0pxtZIw0nRb/X56u8vjOXnjlDPEDEIwaNnhI+VR"
-           "uzE2Caq4Xt7lilCtviZPyJXtceZ5SOh0pkZYrccSWln2+JuBDh+f3O2dOjxl5yZl"
-           "XYcjYinabHXoRdhMG5pTC0X0TMCnl+Q1EsrFDNNwmDaXszR5MU7I/X3mgC3ulp8e"
-           "j/bRF+3Y36I5ELBjTTj7A8Kd/WvafJzoe6fHUbo5uytY4ztXzmkiZXIdcOKsCvsd"
-           "VBa4KOgROKhpFOIHhlXNV97Pl++QslL0gho9Rc0+NbKNlXyz1EyaDXMR5cXc/Ak="
-           "-----END X509 CRL-----")
-          "\n"))
+         (concat
+           "-----BEGIN X509 CRL-----\n"
+           "MIIBqzCBlAIBATANBgkqhkiG9w0BAQsFADA8MRowGAYDVQQDDBFDQSBUZXN0VG9v\n"
+           "bCBDQSAwMTEeMBwGA1UECgwVQ0EgVGVzdFRvb2wgQXV0aG9yaXR5Fw0yMjA2MTEw\n"
+           "NjA5NTZaGA8yMDcyMDUyOTA2MDk1NlowIjAgAgECFw0yMjA2MTEwNjA5MzlaMAww\n"
+           "CgYDVR0VBAMKAQAwDQYJKoZIhvcNAQELBQADggEBAAeCzW8Qjb9T0Y7GUygw+J28\n"
+           "HH6LLprpUsxf9YuHXtrq6IcsM0pxtZIw0nRb/X56u8vjOXnjlDPEDEIwaNnhI+VR\n"
+           "uzE2Caq4Xt7lilCtviZPyJXtceZ5SOh0pkZYrccSWln2+JuBDh+f3O2dOjxl5yZl\n"
+           "XYcjYinabHXoRdhMG5pTC0X0TMCnl+Q1EsrFDNNwmDaXszR5MU7I/X3mgC3ulp8e\n"
+           "j/bRF+3Y36I5ELBjTTj7A8Kd/WvafJzoe6fHUbo5uytY4ztXzmkiZXIdcOKsCvsd\n"
+           "VBa4KOgROKhpFOIHhlXNV97Pl++QslL0gho9Rc0+NbKNlXyz1EyaDXMR5cXc/Ak=\n"
+           "-----END X509 CRL-----"))
         shadow-buffer)
     (with-temp-buffer
       (insert text)

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -230,15 +230,6 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
     (should (string-match-p "Certificate:" (buffer-string)))
     (kill-buffer)))
 
-(ert-deftest x509-viewcert-pem ()
-  "View PEM coded cert."
-  (with-temp-buffer
-    (insert-file-contents-literally (find-testfile "CA/pki/crt/jobbflykt.crt"))
-    (x509-viewcert)
-    (should (derived-mode-p 'x509-mode))
-    (should (string-match-p "Certificate:" (buffer-string)))
-    (kill-buffer)))
-
 (ert-deftest x509-viewreq ()
   "View cert request."
   (with-temp-buffer

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -1,0 +1,59 @@
+(require 'ert)
+
+(require 'x509-mode)
+
+(defun x509--test-make-gmt-time (&optional offset-seconds)
+  "Return a time string.
+Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
+  (let ((offset (or offset-seconds 0)))
+    (format-time-string "%b %e %H:%M:%S %Y GMT"
+                        (time-add (current-time) offset)
+                        "GMT")))
+
+
+(ert-deftest x509--date-in-the-past ()
+  "Find date in buffer that is in the past."
+  (with-temp-buffer
+    (let ((old-date (x509--test-make-gmt-time -60))
+          (future-date (x509--test-make-gmt-time 60)))
+      (insert old-date)
+      (goto-char (point-min))
+      (should (x509--match-date-in-past nil))
+      (should (string= (match-string-no-properties 0) old-date)))))
+
+(ert-deftest x509--date-in-the-future ()
+  "Find date in buffer that is in the future."
+  (with-temp-buffer
+    (let ((future-date (x509--test-make-gmt-time 60)))
+      (insert future-date)
+      (goto-char (point-min))
+      (should (x509--match-date-in-future (point-max)))
+      (should (string= (match-string-no-properties 0) future-date)))))
+
+(ert-deftest x509--load-data-file()
+  "Turn file into list of strings."
+  (let* ((text (concat "# comment 1\n"
+                       "  \n"
+                       "data 1\n"
+                       "\n"
+                       " # comment 2\n"
+                       "2\n"))
+         (tmp-file (make-temp-file "data" nil nil text))
+         (data (x509--load-data-file tmp-file)))
+    (delete-file tmp-file)
+    (should (equal data '("data 1" "2")))))
+
+(ert-deftest x509--pem-region()
+  "Find region delimited by BEGIN/END"
+  (with-temp-buffer
+    (insert "-----BEGIN TYPE----- -----END BOGUS-----END TYPE----- -----END TYPE-----")
+    (goto-char (point-min))
+    (let ((region (x509--pem-region)))
+      (should region)
+      (should (equal 1 (car region)))
+      (should (equal 54 (cdr region))))
+    (goto-char 22)
+    (let ((region (x509--pem-region)))
+      (should region)
+      (should (equal 1 (car region)))
+      (should (equal 54 (cdr region))))))

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -206,3 +206,28 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
   (should (equal 'x509--viewkey-history (x509--get-x509-history "pkey")))
   (should (equal 'x509--viewasn1-history (x509--get-x509-history "asn1parse")))
   (should (equal nil (x509--get-x509-history "UNKNOWN"))))
+
+
+(defun find-testfile(file-name)
+  "Find file-name in testfiles"
+  (expand-file-name file-name "testfiles"))
+
+(ert-deftest x509-viewcert-pem ()
+  "View PEM coded cert."
+  (with-temp-buffer
+    (insert-file-contents-literally (find-testfile "CA/pki/crt/jobbflykt.crt"))
+    (x509-viewcert)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate:" (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewcert-der ()
+  "View PEM coded cert."
+  (with-temp-buffer
+    (insert-file-contents-literally (find-testfile "CA/pki/crt/jobbflykt.cer"))
+    (x509-viewcert)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate:" (buffer-string)))
+    (kill-buffer)))
+
+;; FIXME: Test all x509-viewXXX functions.

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -222,7 +222,7 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
     (kill-buffer)))
 
 (ert-deftest x509-viewcert-der ()
-  "View PEM coded cert."
+  "View DER coded cert."
   (with-temp-buffer
     (insert-file-contents-literally (find-testfile "CA/pki/crt/jobbflykt.cer"))
     (x509-viewcert)
@@ -230,4 +230,83 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
     (should (string-match-p "Certificate:" (buffer-string)))
     (kill-buffer)))
 
-;; FIXME: Test all x509-viewXXX functions.
+(ert-deftest x509-viewcert-pem ()
+  "View PEM coded cert."
+  (with-temp-buffer
+    (insert-file-contents-literally (find-testfile "CA/pki/crt/jobbflykt.crt"))
+    (x509-viewcert)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate:" (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewreq ()
+  "View cert request."
+  (with-temp-buffer
+    (insert-file-contents-literally
+     (find-testfile "CA/ca/request/jobbflykt.pem"))
+    (x509-viewreq)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate Request:" (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewcrl-der ()
+  "View DER-coded CRL."
+  (with-temp-buffer
+    (insert-file-contents-literally
+     (find-testfile "CA/pki/crl/ca_testtool_ca_01.crl"))
+    (x509-viewcrl)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate Revocation List (CRL):"
+                            (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewcrl-pem ()
+  "View PEM-coded CRL."
+  (with-temp-buffer
+    (insert-file-contents-literally
+     (find-testfile "CA/pki/crl/ca_testtool_ca_01_crl.pem"))
+    (x509-viewcrl)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate Revocation List (CRL):"
+                            (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewpkcs7 ()
+  "View pkcs7."
+  (with-temp-buffer
+    (insert-file-contents-literally
+     (find-testfile "CA/pki/pkcs7/jobbflykt.p7b"))
+    (x509-viewpkcs7)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Certificate:"
+                            (buffer-string)))
+    (should (string-match-p "Certificate Revocation List (CRL):"
+                            (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewdh ()
+  "View Diffie-Hellman parameters."
+  (with-temp-buffer
+    (insert-file-contents-literally (find-testfile "dhparams-4096.pem"))
+    (x509-viewdh)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "DH Parameters: (4096 bit)" (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewkey ()
+  "View plaintext private key."
+  (with-temp-buffer
+    (insert-file-contents-literally (find-testfile "CA/pki/key/jobbflykt.key"))
+    (x509-viewkey)
+    (should (derived-mode-p 'x509-mode))
+    (should (string-match-p "Private-Key: (2048 bit)" (buffer-string)))
+    (kill-buffer)))
+
+(ert-deftest x509-viewasn1 ()
+  "View plaintext private key as ASN.1."
+  (with-temp-buffer
+    (insert-file-contents-literally (find-testfile "CA/pki/crt/jobbflykt.crt"))
+    (x509-viewasn1)
+    (should (derived-mode-p 'x509-asn1-mode))
+    (should (string-match-p ":X509v3 Subject Key Identifier" (buffer-string)))
+    (kill-buffer)))

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -38,8 +38,11 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
                        "\n"
                        " # comment 2\n"
                        "2\n"))
-         (tmp-file (make-temp-file "data" nil nil text))
-         (data (x509--load-data-file tmp-file)))
+         (tmp-file (make-temp-file "data"))
+         data)
+    (with-temp-file tmp-file
+      (insert text))
+    (setq data (x509--load-data-file tmp-file))
     (delete-file tmp-file)
     (should (equal data '("data 1" "2")))))
 

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -7,7 +7,7 @@
 Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
   (let ((offset (or offset-seconds 0)))
     (format-time-string "%b %e %H:%M:%S %Y GMT"
-                        (time-add (current-time) offset)
+                        (time-add (current-time) (seconds-to-time offset))
                         "GMT")))
 
 

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -299,7 +299,7 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
     (insert-file-contents-literally (find-testfile "CA/pki/key/jobbflykt.key"))
     (x509-viewkey)
     (should (derived-mode-p 'x509-mode))
-    (should (string-match-p "Private-Key: (2048 bit)" (buffer-string)))
+    (should (string-match-p "publicExponent: 65537 (0x10001)" (buffer-string)))
     (kill-buffer)))
 
 (ert-deftest x509-viewasn1 ()

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -143,13 +143,16 @@ Ex: \"Wed Aug 17 08:48:06 2022 GMT\""
     (with-temp-buffer
       (insert text)
       (goto-char (point-min))
-      (x509--process-buffer (current-buffer) '("crl" "-text" "-noout"))
-      (should (re-search-forward "Certificate Revocation List (CRL):" nil t))
-      (should (string-match-p "^\\*x-.*\\*" (buffer-name)))
-      (should (boundp 'x509--shadow-buffer))
-      (should (bufferp x509--shadow-buffer))
-      (should (buffer-live-p x509--shadow-buffer))
-      (setq shadow-buffer x509--shadow-buffer)
-      (kill-buffer)
-      ;; Shadow buffer should be killed in hook
-      (should-not (buffer-live-p shadow-buffer)))))
+      (let ((result-buffer (x509--process-buffer
+                            (current-buffer) '("crl" "-text" "-noout"))))
+        (should result-buffer)
+        (with-current-buffer result-buffer
+          (should (re-search-forward "Certificate Revocation List (CRL):" nil t))
+          (should (string-match-p "^\\*x-.*\\*" (buffer-name)))
+          (should (boundp 'x509--shadow-buffer))
+          (should (bufferp x509--shadow-buffer))
+          (should (buffer-live-p x509--shadow-buffer))
+          (setq shadow-buffer x509--shadow-buffer)
+          (kill-buffer)
+          ;; Shadow buffer should be killed in hook
+          (should-not (buffer-live-p shadow-buffer)))))))

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -448,11 +448,12 @@ Run when killing a view buffer for cleaning up associated input buffer."
 
 Pass content INPUT-BUF to openssl with
 OPENSSL-ARGUMENTS. E.g. x509 -text.  If OUTPUT-BUF is non-'nil',
-out to that buffer instead of generating a new one."
+output to that buffer instead of generating a new one."
   (interactive)
   (let* ((buf (or output-buf
                   (generate-new-buffer (generate-new-buffer-name
                                         (format "*x-%s*" (buffer-name))))))
+         ;; Operate on whole buffer. Output to buf
          (args (append
                 (list nil nil x509-openssl-cmd nil buf nil)
                 openssl-arguments)))
@@ -463,7 +464,6 @@ out to that buffer instead of generating a new one."
     (add-hook 'kill-buffer-hook 'x509--kill-shadow-buffer nil t)
     (with-current-buffer input-buf
       (apply 'call-process-region args))
-    ;; remember input-buffer and arguments
     (goto-char (point-min))
     (set-buffer-modified-p nil)
     (setq buffer-read-only t)))

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Fredrik Axelsson <f.axelsson@gmai.com>
 ;; Homepage: https://github.com/jobbflykt/x509-mode
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Add github workflow files that builds and runs unit tests on different emacs versions.
Require at least emacs 25.1 to run x509-mode. There is some problem with command history on emacs 24.3 that is unresolved.