### PR TITLE
Highlight dates in the near future

### DIFF
--- a/notes.org
+++ b/notes.org
@@ -208,9 +208,8 @@ Revoked Certificates:
 #+end_example
 * viewpkcs12
 pkcs12 -info -nodes -passin pass:
-* TODO Highlight near expires
+* DONE Highlight near expires
 Customizable time before expire highlight. Some "almost" warning face.
-Also customizable highlight expired, yes/no.
 * TODO Heuristic for dwim on DER data
 Certs, CRLs and other entities should be recognized as such by examining the
 ASN.1 structure.

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -248,7 +248,7 @@ Set to `nil' to inhibit warning."
             ;; later emacs uses just one, the time. If support for emacs 25.1 is
             ;; dropped, there is no need for `funcall' here.
             (setq encoded-now-plus-delta
-                  (funcall 'encode-time decoded-now-plus-delta))
+                  (apply 'encode-time decoded-now-plus-delta))
             (time-less-p time encoded-now-plus-delta))))
    bound))
 

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -242,12 +242,6 @@ Set to `nil' to inhibit warning."
                   (message-log-max nil))
               (setq decoded-now-plus-delta (decoded-time-add decoded-now delta)))
             (setq encoded-now-plus-delta (encode-time decoded-now-plus-delta))
-            ;; (message "delta %s" delta)
-            ;; (message "decoded time %s" decoded-now)
-            ;; (message "decoded time plus delta %s" decoded-now-plus-delta)
-            ;; (message "encoded time plus delta %s" encoded-now-plus-delta)
-            ;; (message "time-less-p time encoded-now-plus-delta %s"
-            ;;          (time-less-p time encoded-now-plus-delta))
             (time-less-p time encoded-now-plus-delta))))
    bound))
 

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -54,6 +54,9 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+(require 'time-date)
+
 (defgroup x509 nil
   "View certificates, CRLs, keys and other related files using OpenSSL."
   :group 'extensions
@@ -266,8 +269,6 @@ Set to `nil' to inhibit warning."
            'action (lambda (button)
                      (browse-url
                       (button-get button 'x509-browse-url-face)))))))))
-
-(require 'cl-lib)
 
 (defun x509--load-data-file (filename)
   "Split FILENAME linewise into a list.

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -221,35 +221,24 @@ Set to `nil' to inhibit warning."
   :group 'x509)
 
 (defun x509--match-date-near-now (bound)
+  "Return non-nil it can find a date that is \"near\" in the future.
+
+\"Near\" is defined by `x509-warn-near-expire-days'.
+Intended to search for dates in form \"Jun 11 00:00:01 2014 GMT\"
+and compare them to the current time. Return non-nil, move point,
+and set ‘match-data’ appropriately if it succeeds; like
+‘re-search-forward’ would.  The optional argument BOUND is a
+buffer position that bounds the search."
   (x509--match-date
    (lambda (time now)
-     ;; We should highlight near expire times
+     ;; If we should highlight near expire times
      ;; and time is not in the future
      ;; and time is within decoded-time-delta from now
      (and x509-warn-near-expire-days
           (time-less-p now time)
-          (let* ((inhibit-message t)
-                 (message-log-max nil)
-
-                 (delta (make-decoded-time
-                         :day x509-warn-near-expire-days))
-                 (decoded-now (decode-time now))
-                 decoded-now-plus-delta
-                 encoded-now-plus-delta)
-            ;; FIXME The message "obsolete timestamp with cdr" appears when
-            ;; decoded-time-add is called. Has something to do with
-            ;; WARN_OBSOLETE_TIMESTAMPS in timefns.c but I don't understand
-            ;; what the correct thing to do is.  For now, inhibit message while
-            ;; doing time calculations
-            (let ((inhibit-message t)
-                  (message-log-max nil))
-              (setq decoded-now-plus-delta (decoded-time-add decoded-now delta)))
-            ;; FIXME In emacs 25.1, encode-time needs 6+ arguments while
-            ;; later emacs uses just one, the time. If support for emacs 25.1 is
-            ;; dropped, there is no need for `funcall' here.
-            (setq encoded-now-plus-delta
-                  (apply 'encode-time decoded-now-plus-delta))
-            (time-less-p time encoded-now-plus-delta))))
+          (time-less-p time
+                       (time-add now
+                                 (* x509-warn-near-expire-days 24 60 60)))))
    bound))
 
 (defun x509--mark-browse-url-links()

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -244,7 +244,11 @@ Set to `nil' to inhibit warning."
             (let ((inhibit-message t)
                   (message-log-max nil))
               (setq decoded-now-plus-delta (decoded-time-add decoded-now delta)))
-            (setq encoded-now-plus-delta (encode-time decoded-now-plus-delta))
+            ;; FIXME In emacs 25.1, encode-time needs 6+ arguments while
+            ;; later emacs uses just one, the time. If support for emacs 25.1 is
+            ;; dropped, there is no need for `funcall' here.
+            (setq encoded-now-plus-delta
+                  (funcall 'encode-time decoded-now-plus-delta))
             (time-less-p time encoded-now-plus-delta))))
    bound))
 

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -157,7 +157,7 @@ Example:
   :group 'x509-faces)
 
 (defface x509-near-warning-face
-  '((t (:inherit font-lock-variable-name-face :inverse-video t)))
+  '((t (:inherit font-lock-function-name-face :inverse-video nil)))
   "Face for near expire date/time values."
   :group 'x509-faces)
 
@@ -220,21 +220,22 @@ Set to `nil' to inhibit warning."
 (defun x509--match-date-near-now (bound)
   (x509--match-date
    (lambda (time now)
-     (message "Comparing %s %s (less %s)" time now (time-less-p time now))
      ;; time is not in the future
      ;; and time is within decoded-time-delta from now
-     (let* ((delta (make-decoded-time
-                   :day x509-warn-near-expire-days))
-           (decoded-now (decode-time now))
-           (decoded-now-plus-delta (decoded-time-add decoded-now delta))
-           (encoded-now-plus-delta (encode-time decoded-now-plus-delta)))
-       (message "delta %s" delta)
-       (message "decoded time %s" decoded-now)
-       (message "decoded time plus delta %s" decoded-now-plus-delta)
-       (message "encoded time plus delta %s" encoded-now-plus-delta)
-       (message "time-less-p time encoded-now-plus-delta %s"
-                (time-less-p time encoded-now-plus-delta))
-       (time-less-p time encoded-now-plus-delta)))
+     (and x509-warn-near-expire-days)
+     (and (time-less-p now time)
+          (let* ((delta (make-decoded-time
+                         :day x509-warn-near-expire-days))
+                 (decoded-now (decode-time now))
+                 (decoded-now-plus-delta (decoded-time-add decoded-now delta))
+                 (encoded-now-plus-delta (encode-time decoded-now-plus-delta)))
+            ;; (message "delta %s" delta)
+            ;; (message "decoded time %s" decoded-now)
+            ;; (message "decoded time plus delta %s" decoded-now-plus-delta)
+            ;; (message "encoded time plus delta %s" encoded-now-plus-delta)
+            ;; (message "time-less-p time encoded-now-plus-delta %s"
+            ;;          (time-less-p time encoded-now-plus-delta))
+            (time-less-p time encoded-now-plus-delta))))
    bound))
 
 (defun x509--mark-browse-url-links()
@@ -336,7 +337,7 @@ Skip blank lines and comment lines.  Return list."
    '("\\(Not Before\\): " (1 'x509-keyword-face)
      (x509--match-date-in-future nil nil (0 'x509-warning-face)))
    '("\\(Not After\\) : " (1 'x509-keyword-face)
-     ;;(x509--match-date-in-past nil nil (0 'x509-warning-face))
+     (x509--match-date-in-past nil nil (0 'x509-warning-face))
      (x509--match-date-near-now nil nil (0 'x509-near-warning-face)))
    ;; For CRL's when Next Update is in the past
    '("\\(Next Update\\): " (1 'x509-keyword-face)


### PR DESCRIPTION
Highlight "Not After" date/times in certificates that are "close" to the current time.
"Close" is determined by the new customizable variable x509-warn-near-expire-days.