### PR TITLE
Add "Signature Value" keyword

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -21,6 +21,7 @@ No Rejected Uses.
 Alias:
 Key Id:
 keyid:
+Signature Value:
 
 # openssl/crypto/x509v3/v3_alt.c
 X400Name:

--- a/notes.org
+++ b/notes.org
@@ -246,3 +246,8 @@ going down and up. The stack also records point before going down, restoring it
 when backing up.
 
 x509--ans1parse-offset-stack = (653 718)
+* TODO Add support for OpenSSL 3
+For example "Signature Value" is shown after
+     Signature Algorithm: sha256WithRSAEncryption
+new> Signature Value:
+          12:74:61...

--- a/notes.org
+++ b/notes.org
@@ -246,7 +246,7 @@ going down and up. The stack also records point before going down, restoring it
 when backing up.
 
 x509--ans1parse-offset-stack = (653 718)
-* TODO Add support for OpenSSL 3
+* DONE Add support for OpenSSL 3
 For example "Signature Value" is shown after
      Signature Algorithm: sha256WithRSAEncryption
 new> Signature Value:


### PR DESCRIPTION
openssl 3 prefixes signatures with "Signature Value:". Add font lock.