### PR TITLE
Test on emacs-29

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
     - name: Checkout x509-mode
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: jobbflykt/x509-mode
         path: x509-mode


### PR DESCRIPTION
- Test on emacs-29.1
- Remove testing on emacs-28.1, keep test on emacs 28.2.
- Update actions/checkout@v3 to silence warning about deprecated node12.