### PR TITLE
Use new and preferred keymap-set from emacs-29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 all: lisp
 
+DEPS = compat
+
 TOP := .
-LOAD_PATH = -L $(TOP)
+LOAD_PATH += $(addprefix -L ../,$(DEPS))
+LOAD_PATH += -L $(TOP)
 EMACS ?= emacs
 BATCH = $(EMACS) -Q --batch $(LOAD_PATH)
 

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,20 @@ TOP := .
 LOAD_PATH += -L $(TOP)
 EMACS ?= emacs
 BATCH = $(EMACS) -Q --batch $(LOAD_PATH)
-REQUIRES = package-lint compat
+REQUIRES = compat
 PACKAGES="(progn \
   (require 'package) \
-  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
-  (push '(\"gnu-elpa\" . \"http://mirrors.rockylinux.org/melpa/gnu-elpa/\") \
-        package-archives) \
   (package-initialize) \
   (dolist (pkg '(${REQUIRES})) \
     (unless (package-installed-p pkg) \
       (unless (assoc pkg package-archive-contents) \
         (package-refresh-contents)) \
-      (package-install pkg))) \
-  )"
+      (package-install pkg))))"
+
+# Future: Add package-lint to REQUIRES and melpa to package-archives.
+#         Create a target with runs -f package-lint-batch-and-exit x509-mode.el
+# REQUIRES += package-lint
+# (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
 
 ELS = x509-mode.el
 ELCS = $(ELS:.el=.elc)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,23 @@
 
 all: lisp
 
-DEPS = compat
-
 TOP := .
-LOAD_PATH += $(addprefix -L ../,$(DEPS))
 LOAD_PATH += -L $(TOP)
 EMACS ?= emacs
 BATCH = $(EMACS) -Q --batch $(LOAD_PATH)
+REQUIRES = package-lint compat
+PACKAGES="(progn \
+  (require 'package) \
+  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
+  (push '(\"gnu-elpa\" . \"http://mirrors.rockylinux.org/melpa/gnu-elpa/\") \
+        package-archives) \
+  (package-initialize) \
+  (dolist (pkg '(${REQUIRES})) \
+    (unless (package-installed-p pkg) \
+      (unless (assoc pkg package-archive-contents) \
+        (package-refresh-contents)) \
+      (package-install pkg))) \
+  )"
 
 ELS = x509-mode.el
 ELCS = $(ELS:.el=.elc)
@@ -16,7 +26,7 @@ ELCS = $(ELS:.el=.elc)
 lisp: $(ELCS)
 
 %.elc: %.el
-	$(BATCH) --eval \
+	$(BATCH) --eval $(PACKAGES) --eval \
           "(progn \
              (when (file-exists-p \"$@\") (delete-file \"$@\")) \
              (setq byte-compile-error-on-warn t))" \
@@ -24,7 +34,7 @@ lisp: $(ELCS)
 
 test:
 	openssl version
-	$(BATCH) --eval "\
+	$(BATCH) --eval $(PACKAGES) --eval "\
 	(progn \
 	  (message \"%s\" (emacs-version)) \
 	  (load-file \"$(TOP)/x509-mode.el\") \

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Fredrik Axelsson <f.axelsson@gmail.com>
 ;; Homepage: https://github.com/jobbflykt/x509-mode
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "25.1") (compat "29.1.4.2"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -71,6 +71,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'compat)
 
 (defgroup x509 nil
   "View certificates, CRLs, keys and other related files using OpenSSL."
@@ -443,9 +444,9 @@ Skip blank lines and comment lines.  Return list."
 
 \\{x509-mode-map}"
  (set (make-local-variable 'font-lock-defaults) '(x509-font-lock-keywords t))
- (define-key x509-mode-map "q" 'x509-mode--kill-buffer)
- (define-key x509-mode-map "t" 'x509--toggle-mode)
- (define-key x509-mode-map "e" 'x509--edit-params)
+ (keymap-set x509-mode-map "q" #'x509-mode--kill-buffer)
+ (keymap-set x509-mode-map "t" #'x509--toggle-mode)
+ (keymap-set x509-mode-map "e" #'x509--edit-params)
  (x509--mark-browse-http-links)
  (x509--mark-browse-oid))
 
@@ -1408,13 +1409,13 @@ The ASN.1 header uses `x509-asn1-hexl-header' face and the value uses the
 \\{x509-asn1-mode-map}"
  (set
   (make-local-variable 'font-lock-defaults) '(x509-asn1-font-lock-keywords t))
- (define-key x509-asn1-mode-map "q" 'x509-mode--kill-buffer)
- (define-key x509-asn1-mode-map "t" 'x509--toggle-mode)
- (define-key x509-asn1-mode-map "e" 'x509--edit-params)
- (define-key x509-asn1-mode-map "d" 'x509--asn1-offset-down)
- (define-key x509-asn1-mode-map "s" 'x509--asn1-strparse)
- (define-key x509-asn1-mode-map "u" 'x509--asn1-offset-up)
- (define-key x509-asn1-mode-map "x" 'x509-asn1-toggle-hexl)
+ (keymap-set x509-asn1-mode-map "q" #'x509-mode--kill-buffer)
+ (keymap-set x509-asn1-mode-map "t" #'x509--toggle-mode)
+ (keymap-set x509-asn1-mode-map "e" #'x509--edit-params)
+ (keymap-set x509-asn1-mode-map "d" #'x509--asn1-offset-down)
+ (keymap-set x509-asn1-mode-map "s" #'x509--asn1-strparse)
+ (keymap-set x509-asn1-mode-map "u" #'x509--asn1-offset-up)
+ (keymap-set x509-asn1-mode-map "x" #'x509-asn1-toggle-hexl)
  (x509--mark-browse-http-links)
  (x509--mark-browse-oid))
 


### PR DESCRIPTION
Requires compat to work on older emacs version. Update CI.