### PR TITLE
Run melpazoid in CI

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         LOCAL_REPO: ${{ github.workspace }}
         # RECIPE is your recipe as written for MELPA:
-        RECIPE: (x509-mode :repo "jobbflykt/x509-mode" :fetcher github)
+        RECIPE: (x509-mode :fetcher github :repo "jobbflykt/x509-mode" :files (:defaults "*.txt"))
         # set this to false (or remove it) if the package isn't on MELPA:
         EXIST_OK: true
       run: echo $GITHUB_REF && make -C ~/melpazoid

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -1,0 +1,31 @@
+# melpazoid <https://github.com/riscy/melpazoid> build checks.
+
+# If your package is on GitHub, enable melpazoid's checks by copying this file
+# to .github/workflows/melpazoid.yml and modifying RECIPE and EXIST_OK below.
+
+name: melpazoid
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        sudo apt-get install emacs && emacs --version
+        git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+        pip install ~/melpazoid
+    - name: Run
+      env:
+        LOCAL_REPO: ${{ github.workspace }}
+        # RECIPE is your recipe as written for MELPA:
+        RECIPE: (x509-mode :repo "jobbflykt/x509-mode" :fetcher github)
+        # set this to false (or remove it) if the package isn't on MELPA:
+        EXIST_OK: true
+      run: echo $GITHUB_REF && make -C ~/melpazoid

--- a/x509-mode-tests.el
+++ b/x509-mode-tests.el
@@ -220,7 +220,7 @@ When `x509-warn-near-expire-days' is nil."
     (goto-char (point-min))
     (should-not (x509--pem-region-type))))
 
-(ert-deftest x509--pem-region-next/prev ()
+(ert-deftest x509--pem-region-next-or-prev ()
   (with-temp-buffer
     (insert
      ;; This is the initial valid region
@@ -235,20 +235,22 @@ When `x509-warn-near-expire-days' is nil."
           (expected-next-point 85))
       (should first-region)
       (should (= 1 (car first-region)))
-      (let ((next-region (x509--pem-region-next/prev (current-buffer) 'next)))
+      (let ((next-region
+             (x509--pem-region-next-or-prev (current-buffer) 'next)))
         (should next-region)
         (should (= expected-next-point (car next-region)))
         (should (= expected-next-point (point)))
         ;; Next again should leave point unchanged
-        (should-not (x509--pem-region-next/prev (current-buffer) 'next))
+        (should-not (x509--pem-region-next-or-prev (current-buffer) 'next))
         (should (= expected-next-point (point))))
       ;; Prev 1
-      (let ((prev-region (x509--pem-region-next/prev (current-buffer) 'prev)))
+      (let ((prev-region
+             (x509--pem-region-next-or-prev (current-buffer) 'prev)))
         (should prev-region)
         (should (= 1 (car prev-region)))
         (should (= 1 (point)))
         ;; Prev again should leave point unchanged
-        (should-not (x509--pem-region-next/prev (current-buffer) 'prev))
+        (should-not (x509--pem-region-next-or-prev (current-buffer) 'prev))
         (should (= 1 (point)))))))
 
 (ert-deftest x509--generate-input-buffer ()
@@ -704,7 +706,7 @@ SEQUENCE             30 0C
     (let ((content (buffer-substring-no-properties (point-min) (point-max))))
       (should (string-match-p expected-string content)))))
 
-(ert-deftest x509-dwim-next/prev ()
+(ert-deftest x509-dwim-next-or-prev ()
   "Go forward and backward."
   (with-temp-buffer
     (insert-file-contents-literally (find-testfile "multi.pem"))
@@ -757,7 +759,7 @@ SEQUENCE             30 0C
       (with-current-buffer view-buffer
         (x509-mode-kill-buffer)))))
 
-(ert-deftest x509-dwim-next/prev-asn1 ()
+(ert-deftest x509-dwim-next-or-prev-asn1 ()
   "Go forward and backward in `x509-asn1-mode'."
   (with-temp-buffer
     (insert-file-contents-literally (find-testfile "multi.pem"))

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -1,16 +1,18 @@
 ;;; x509-mode.el --- View certificates, CRLs and keys using OpenSSL  -*- lexical-binding:t; coding:utf-8 -*-
 
-;; Copyright (C) 2017-2023 Fredrik Axelsson <f.axelsson@gmail.com>
+;; Copyright (C) 2017-2025 Fredrik Axelsson <f.axelsson@gmail.com>
 
 ;; Author: Fredrik Axelsson <f.axelsson@gmail.com>
 ;; Homepage: https://github.com/jobbflykt/x509-mode
-;; Package-Requires: ((emacs "25.1") (compat "29.1.4.2"))
+
+;; Package-Version: 2.0.0
+;; Package-Requires: ((emacs "25.1") (compat "29.1"))
 
 ;; This file is not part of GNU Emacs.
 
 ;; MIT License
 ;;
-;; Copyright (C) 2017-2023 Fredrik Axelsson <f.axelsson@gmail.com>
+;; Copyright (C) 2017-2025 Fredrik Axelsson <f.axelsson@gmail.com>
 ;;
 ;; Permission is hereby granted, free of charge, to any person obtaining a copy
 ;; of this software and associated documentation files (the "Software"), to

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -1146,7 +1146,7 @@ Return view buffer on success."
       (when-let* ((tmp-output-buffer (x509--do-dwim t)))
         (with-current-buffer tmp-output-buffer
           ;; Only consider x509-mode output. We don't want asn1.
-          (if (eq major-mode 'x509-mode)
+          (if (derived-mode-p 'x509-mode)
               (let ((new-content
                      (buffer-substring-no-properties (point-min) (point-max))))
                 (with-current-buffer swoop-buffer

--- a/x509-mode.el
+++ b/x509-mode.el
@@ -344,22 +344,16 @@ For simple cases, COMPOSE-URL-FN returns its argument unchanged."
 Skip blank lines and comment lines.  Return list."
     ;; Try to guess path to filename. It may not be in the current directory
     ;; when compiling.
-    (let (path)
-      (if (bound-and-true-p byte-compile-current-file)
-          (let ((test-path
-                 (expand-file-name filename
-                                   (file-name-directory
-                                    byte-compile-current-file))))
-            (if (file-exists-p test-path)
-                (setq path test-path))))
-      (if (and (not path) (bound-and-true-p load-file-name))
-          (let ((test-path
-                 (expand-file-name filename
-                                   (file-name-directory load-file-name))))
-            (if (file-exists-p test-path)
-                (setq path test-path))))
-      (if (not path)
-          (setq path filename))
+    (let ((path
+           (cond
+            ((bound-and-true-p byte-compile-current-file)
+             (expand-file-name filename
+                               (file-name-directory
+                                byte-compile-current-file)))
+            ((bound-and-true-p load-file-name)
+             (expand-file-name filename (file-name-directory load-file-name)))
+            (t
+             filename))))
       (with-temp-buffer
         (insert-file-contents path)
         (cl-remove-if


### PR DESCRIPTION
Run melpazoid in CI and fix found issues.

```
* .github/workflows/melpazoid.yml: New. Run melpazoid package
verifier.
* x509-mode-tests.el
(x509--pem-region-next-or-prev): Renamed to not use '/'.  Call
renamed function.
(x509-dwim-next-or-prev): Ditto.
(x509-dwim-next-or-prev-asn1): Ditto.
* x509-mode.el: Bump copyright year.
(Package-Version): New, requested by melpazoid.
(Package-Requires): Require compat 29.1, i.e. be less specific.
(x509--pem-region-next-or-prev): Renamed to not use '/'.
(x509--dwim-next-or-prev): Ditto.
(x509-swoop): Use `derived-mode-p' to check for x509-mode.
```